### PR TITLE
Fix klinecharts undefined length error

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -47,9 +47,18 @@ function ensureRegisterIndicator() {
       const name = "BOLL";
       const calcParamsText = `(${indicator.calcParams[0]}, ${indicator.calcParams[1]}, ${indicator.calcParams[2]})`;
       const legends = [
-        { color: "#9ca3af", text: `Basis: ${res.basis ?? "-"}` },
-        { color: "#22d3ee", text: `Upper: ${res.upper ?? "-"}` },
-        { color: "#22d3ee", text: `Lower: ${res.lower ?? "-"}` },
+        {
+          title: { text: "Basis:", color: "#9ca3af" },
+          value: { text: `${res.basis ?? "-"}`, color: "#9ca3af" },
+        },
+        {
+          title: { text: "Upper:", color: "#22d3ee" },
+          value: { text: `${res.upper ?? "-"}`, color: "#22d3ee" },
+        },
+        {
+          title: { text: "Lower:", color: "#22d3ee" },
+          value: { text: `${res.lower ?? "-"}`, color: "#22d3ee" },
+        },
       ];
       return { name, calcParamsText, features: [], legends } as unknown as ReturnType<NonNullable<typeof indicator.createTooltipDataSource>>;
     },


### PR DESCRIPTION
Update klinecharts tooltip legend data structure to fix a `TypeError: Cannot read properties of undefined (reading 'length')`.

The `klinecharts` v10 tooltip renderer expected legend items to have nested `title` and `value` objects, each containing a `text` property. The previous implementation provided a flat structure, leading to the renderer attempting to access `.length` on an `undefined` property.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bd3fafb-2e75-4c79-9b10-d17561da5893">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3bd3fafb-2e75-4c79-9b10-d17561da5893">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

